### PR TITLE
Avoid cloning iDyntree with depth 1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,7 @@ jobs:
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${IPOPT_DIR}/lib
 
         cd ${GITHUB_WORKSPACE}
-        git clone https://github.com/robotology/idyntree --depth 1
+        git clone https://github.com/robotology/idyntree
         cd idyntree
         git checkout ${iDynTree_TAG}
         mkdir build && cd build


### PR DESCRIPTION
Attempt to fix the failure of https://github.com/ami-iit/dynamical-planner/actions/runs/10468480493